### PR TITLE
feat(config): migrate database client from SQLite to PostgreSQL

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -28,8 +28,14 @@ backend:
   # This is for local development only, it is not recommended to use this in production
   # The production database configuration is stored in app-config.production.yaml
   database:
-    client: better-sqlite3
-    connection: ':memory:'
+    client: pg
+    connection:
+      host: localhost
+      port: 5432
+      user: postgres
+      password: secret
+    # client: better-sqlite3
+    # connection: ':memory:'
   # workingDirectory: /tmp # Use this to configure a working directory for the scaffolder, defaults to the OS temp-dir
 
 integrations:


### PR DESCRIPTION
### Summary

This PR updates the Backstage `app-config.yaml` to switch the default database client from `better-sqlite3` (in-memory SQLite) to PostgreSQL (`pg`) for local development.

---

### Changes

- Replaces:
  ```yaml
  client: better-sqlite3
  connection: ':memory:'
  ```
  with:
  ```yaml
  client: pg
  connection:
    host: localhost
    port: 5432
    user: postgres
    password: secret
  ```

- Comments out the previous SQLite config to preserve reference.

---

### How to Test

1. Ensure PostgreSQL is running locally (`localhost:5432`) and the `postgres` user has access.
2. Run:
   ```bash
   yarn dev
   ```
3. The backend should start up without any `Ident authentication` or database client errors.

---

### Notes

- This is a necessary change to enable persistent data across plugin sessions (e.g., catalog, auth, scaffolder).
- Great for teams planning to deploy or scale beyond ephemeral dev environments.

## Summary by Sourcery

Migrate the local development database configuration from in-memory SQLite to PostgreSQL to enable persistent data storage

New Features:
- Introduce PostgreSQL as the default database client for local development

Enhancements:
- Enable persistent data storage across plugin sessions

Chores:
- Update app-config.yaml to switch database configuration